### PR TITLE
Do not produce output to the screen.

### DIFF
--- a/include/sampleflow/consumers/spurious_autocovariance.h
+++ b/include/sampleflow/consumers/spurious_autocovariance.h
@@ -270,19 +270,15 @@ namespace SampleFlow
     {
       std::lock_guard<std::mutex> lock(mutex);
       std::vector<scalar_type> current_autocovariation;
+
       current_autocovariation.resize(autocovariance_length);
       for (unsigned int i=0; i<autocovariance_length; ++i)
         {
           current_autocovariation[i] = 0;
         }
 
-      if (n_samples==0)
+      if (n_samples!=0)
         {
-          std::cout << "There are n any samples yet, returning zero";
-        }
-      else
-        {
-
           unsigned int length1=std::min(static_cast<unsigned int>(n_samples),autocovariance_length);
 
           for (int i=0; i<length1; ++i)


### PR DESCRIPTION
From a user perspective, it is very difficult to tell where this information
was produced, and so is not very useful. It's also obscures legitimate
output in projects that use SampleFlow if they want to generate screen
output themselves. As a consequence, just do what the function
documentation says: Return a default-constructed object.