### PR TITLE
Remove some commentary.

### DIFF
--- a/tests/covariance_matrix_01.cc
+++ b/tests/covariance_matrix_01.cc
@@ -15,8 +15,6 @@
 
 
 // Check the CovarianceMatrix consumer
-// So far, we couldn't use Ranger producer because of insufficiency in Covariance_matrix.h, where code expects
-// input as vallaray, vector, array or etc.
 
 
 #include <iostream>

--- a/tests/spurious_autocovariance_01.cc
+++ b/tests/spurious_autocovariance_01.cc
@@ -15,9 +15,6 @@
 
 
 // Check the SpuriousAutocovariance consumer
-// So far, we couldn't use Ranger producer because of insufficiency in spurious_autocovariance.h,
-// where code expects input as vallaray, vector, array or etc. However, metropolis_hasting algorithm with some
-// modifications in perturb function is totally fine to do this job.
 
 
 #include <iostream>


### PR DESCRIPTION
These comments explain what *doesn't* work, but that is not useful information
to the reader: The reader wants to understand what *does* happen in a given
file. It's also information that tends to go out of date pretty quickly: If
we implement the ability to work with things other than valarray, we would
have to update comments in files that are unrelated to what we are
implementing.

@MantautasRimkus -- FYI.