### PR TITLE
Remove unnecessary include file.

### DIFF
--- a/tests/covariance_matrix_01.cc
+++ b/tests/covariance_matrix_01.cc
@@ -22,7 +22,6 @@
 #include <valarray>
 
 #include <sampleflow/producers/metropolis_hastings.h>
-#include <boost/numeric/ublas/matrix.hpp>
 #include <sampleflow/consumers/covariance_matrix.h>
 
 using SampleType = std::valarray<double>;


### PR DESCRIPTION
There is no need to explicitly #include a BOOST header file that is already
included in the covariance_matrix.h file that uses this class.

@MantautasRimkus -- FYI