### PR TITLE
Introduce Utilities::conj() that actually works.

### DIFF
--- a/include/sampleflow/consumers/covariance_matrix.h
+++ b/include/sampleflow/consumers/covariance_matrix.h
@@ -191,7 +191,7 @@ namespace SampleFlow
               const auto delta_i = Utilities::get_nth_element(delta, i);
               for (unsigned int j=0; j<Utilities::size(sample); ++j)
                 {
-                  const auto delta_j = std::conj(Utilities::get_nth_element(delta, j));
+                  const auto delta_j = Utilities::conj(Utilities::get_nth_element(delta, j));
                   current_covariance_matrix(i,j) += ((delta_i*delta_j)/(1.0*n_samples)) - current_covariance_matrix(i,j)/((1.0*n_samples)-1);
                 }
             }

--- a/include/sampleflow/types.h
+++ b/include/sampleflow/types.h
@@ -17,7 +17,10 @@
 #define SAMPLEFLOW_TYPES_H
 
 #include <cstddef>
+#include <complex>
+
 #include <sampleflow/element_access.h>
+
 
 namespace SampleFlow
 {
@@ -58,6 +61,33 @@ namespace SampleFlow
      */
     template <typename SampleType>
     using ScalarType = decltype(Utilities::get_nth_element(std::declval<SampleType>(), 0));
+  }
+
+
+  namespace Utilities
+  {
+    /**
+     * Form the complex-conjugate of the argument. This function
+     * template is chosen when the argument is not, in fact, complex-valued
+     * and consequently simply returns the argument itself.
+     */
+    template <typename T>
+    T conj (const T &value)
+    {
+      return value;
+    }
+
+
+
+    /**
+     * Form the complex-conjugate of the argument. This function
+     * template is chosen when the argument is complex-valued.
+     */
+    template <typename T>
+    std::complex<T> conj (const std::complex<T> &value)
+    {
+      return std::conj(value);
+    }
   }
 }
 


### PR DESCRIPTION
std::conj() *always* returns a std::complex number, but that is not useful if the argument is in fact not complex-valued at all, and consequently breaks the classes that use std::conj on non-complex objects.

This is a follow-up to #97 . @dawsoneliasen -- you could probably have caught this if you had run `ctest` to run *all* tests, not just the new ones: You'd have found that all existing tests for the `CovarianceMatrix` consumer failed. That's of course not what we want :-)