### PR TITLE
Fix a typo in the YML CI file.

### DIFF
--- a/.github/workflows/SampleFlow-test.yml
+++ b/.github/workflows/SampleFlow-test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+before_script:
+  - apt-get install doxygen -y
+
 jobs:
   build:
 

--- a/.github/workflows/SampleFlow-test.yml
+++ b/.github/workflows/SampleFlow-test.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: cmake
-      run: cmake
+      run: cmake .
     - name: ctest
       run: ctest


### PR DESCRIPTION
@dawsoneliasen -- that was actually quite simple. github has a wizard that helps set up a .yml file for CI actions. I followed it and it automatically committed the CI file into my master branch. I accidentally had a typo in there (I believe), so this is a follow-up PR that fixes that and, with some luck, also tests whether this actually works...