### PR TITLE
CI: small ctest fix

### DIFF
--- a/.github/workflows/SampleFlow-test.yml
+++ b/.github/workflows/SampleFlow-test.yml
@@ -21,4 +21,4 @@ jobs:
     - name: cmake
       run: cmake .
     - name: ctest
-      run: ctest -j8
+      run: ctest --output-on-failure -j2


### PR DESCRIPTION
- the CI runners have only two cores, so using -j8 is not helpful
- let ctest output details when a test fails.