### PR TITLE
Request appropriate cmake version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 # ---------------------------------------------------------------------
 
 
-CMAKE_MINIMUM_REQUIRED (VERSION 3.1)
+CMAKE_MINIMUM_REQUIRED (VERSION 3.8)
 PROJECT (SampleFlow
          CXX)
 


### PR DESCRIPTION
Specifically, the std_cxx_11 target property was only added to cmake in 3.7.