### PR TITLE
Use '\n' instead of 'std::endl'.

### DIFF
--- a/include/sampleflow/consumers/stream_output.h
+++ b/include/sampleflow/consumers/stream_output.h
@@ -184,7 +184,7 @@ namespace SampleFlow
       std::lock_guard<std::mutex> lock(mutex);
 
       internal::StreamOutput::write (sample, output_stream);
-      output_stream << std::endl;
+      output_stream << '\n';
     }
   }
 }


### PR DESCRIPTION
`std::endl` doesn't just put an endline into the stream, but also calls the `flush()` function on the stream. The latter in turn causes the current contents of the memory buffer to be sent to disk, which is causing a lot of file system traffic if done often. This can be avoided by only putting an endline `\n` into the buffer, but leaving the flush operation to whenever that buffer is full.